### PR TITLE
Add the ability to run dartfmt on save

### DIFF
--- a/Support/Dart - Plugin Settings.sublime-settings
+++ b/Support/Dart - Plugin Settings.sublime-settings
@@ -51,6 +51,9 @@
 	// If 'true', the analysis server will run in the background.
 	"dart_enable_analysis_server": true,
 
+	// If 'true', automatically dartfmt Dart files on save.
+	"dartfmt_on_save": false,
+
 	// Log level (for debugging).
 	//Can be one of: debug < info < warning < error < critical
 	"dart_log_level": "error"

--- a/format.py
+++ b/format.py
@@ -12,6 +12,7 @@ from Dart.sublime_plugin_lib import PluginLogger
 from Dart.sublime_plugin_lib.plat import supress_window
 
 from Dart import analyzer
+from Dart.lib.path import is_view_dart_script
 from Dart.lib.sdk import DartFormat
 
 
@@ -36,4 +37,30 @@ class DartReplaceRegion(sublime_plugin.TextCommand):
     def run(self, edit, region, text):
         reg = sublime.Region(*region)
         self.view.replace(edit, reg, text)
-        self.view.run_command('reindent')
+
+
+class DartFormatOnSave(sublime_plugin.EventListener):
+    """Keeps tabs on the views currently being edited and formats them on save
+    if so configured.
+    """
+    def on_pre_save(self, view):
+        if not is_view_dart_script(view):
+            _logger.debug("not a dart file: %s", view.file_name())
+            return
+
+        settings = sublime.load_settings('Dart - Plugin Settings.sublime-settings')
+        dartfmt_on_save = settings.get('dartfmt_on_save')
+        if not dartfmt_on_save:
+            _logger.debug("dartfmt is disabled (dartfmt_on_save is false)")
+            return
+
+        print("Dart format: Running dartfmt on ", view.file_name())
+        # Format the whole view using the dartfmt command, rather than the
+        # analyzer, since we need it to happen synchronously. Otherwise, the
+        # formatting would happen after the save, leaving a dirty view.
+        text = view.substr(sublime.Region(0, view.size()))
+        formatted_text = DartFormat().format(text)
+        view.run_command('dart_replace_region', {
+            'region': [0, view.size()],
+            'text': formatted_text + '\n'
+            })


### PR DESCRIPTION
This feature is off by default, and can be enabled in the user's Dart Plugin Settings.